### PR TITLE
more flexible error handling

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,162 @@
+package gcfg
+
+import (
+	"fmt"
+
+	"github.com/launchdarkly/gcfg/token"
+)
+
+// ErrorAction is a type that is returned by an ErrorHandler function to indicate what to
+// do about a problem.
+type ErrorAction int
+
+const (
+	// ErrorActionNone means that the ErrorHandler has no opinion about the error. It may
+	// be handled by a subsequent error handler, but if not, it will be ignored.
+	ErrorActionNone ErrorAction = iota
+
+	// ErrorActionStop means that the ErrorHandler considers the error to be fatal, so gcfg
+	// should stop processing and return the error to the caller.
+	ErrorActionStop ErrorAction = iota
+
+	// ErrorActionSuppress means that the ErrorHandler wants gcfg to ignore the error. It
+	// will not be passed to any subsequent error handlers.
+	ErrorActionSuppress ErrorAction = iota
+)
+
+// ErrorLocation describes a location where an error occurred. This is provided as part
+// of a TargetNotFoundError, ValueError, or InvalidContainerError.
+//
+// If Field is non-empty, then the problem is with the specified field; Section and
+// Subsection will also be set.
+//
+// If Field is empty, then the problem is with the specified Section and/or Subsection.
+//
+// If all three fields are empty (for InvalidContainerError), the problem is with the
+// target data structure that was passed to the Read function.
+type ErrorLocation struct {
+	Section    string
+	Subsection string
+	Field      string
+}
+
+func (l ErrorLocation) describeLocation() string {
+	switch {
+	case l.Field != "":
+		return fmt.Sprintf("section %q subsection %q variable %q", l.Section, l.Subsection, l.Field)
+	case l.Subsection != "":
+		return fmt.Sprintf("section %q subsection %q", l.Section, l.Subsection)
+	default:
+		return fmt.Sprintf("section %q", l.Section)
+	}
+}
+
+// ParseError is an error that indicates that the configuration data had invalid syntax.
+// The Err value describes what the specific problem was.
+//
+// This type of error always causes gcfg to stop and return the error to the caller, since
+// parsing cannot continue if the input is malformed.
+//
+// Some kinds of syntax errors cause gcfg to return a scanner.Error instead of a ParseError.
+type ParseError struct {
+	token.Position
+	Err error
+}
+
+func (e ParseError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Position, e.Err)
+}
+
+// TargetNotFoundError is an error that indicates a section name or field name in the
+// configuration did not exist in the target data structure.
+//
+// By default, gcfg does not report this type of error. You can use ErrorHandler, with either
+// StopOnTargetNotFound or a custom handler, to change that behavior.
+type TargetNotFoundError struct {
+	ErrorLocation
+}
+
+func (e TargetNotFoundError) Error() string {
+	switch {
+	case e.Field != "":
+		return "invalid variable: " + e.describeLocation()
+	case e.Subsection != "":
+		return "invalid subsection: " + e.describeLocation()
+	default:
+		return "invalid section: " + e.describeLocation()
+	}
+}
+
+// ValueError is an error that indicates that a value in the configuration file was not in a
+// valid format for the corresponding part of the target data structure. For instance, this
+// could mean that an int field was set to a non-numeric string. The Err value indicates
+// what the specific problem was, and the ErrorLocation fields describe where it occurred.
+//
+// By default, if gcfg encounters this type of error, it stops parsing and returns the error.
+// If you use the ErrorHandler option, it will pass this error to the handler function which
+// can determine what to do.
+type ValueError struct {
+	ErrorLocation
+	Err error
+}
+
+func (e ValueError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Err, e.describeLocation())
+}
+
+// InvalidContainerError is an error that indicates that a section within the target data
+// structure was not a valid container type that gcfg can set values in. For instance, this
+// could mean it was not a struct or map, or that it was a map with unsupported key or value
+// types. The Message field describes the problem more specifically.
+//
+// By default, if gcfg encounters this type of error, it panics. If you use the ErrorHandler
+// option, it will pass this error to the handler function which can determine what to do.
+type InvalidContainerError struct {
+	ErrorLocation
+	Message string
+}
+
+func (e InvalidContainerError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Message, e.describeLocation())
+}
+
+// StopOnTargetNotFound can be used with ErrorHandler to change gcfg's behavior regarding
+// unrecognized names.
+//
+// By default, if a section or field in the configuration does not correspond to anything
+// in the target data structure, gcfg skips it. If you specify ErrorHandler(StopOnTargetNotFound),
+// it will instead report this as a TargetNotFoundError.
+//
+// If you want to customize error-reporting behavior in other ways, use ErrorHandler with a
+// custom function.
+//
+//     err := gcfg.ReadFileInto(&configStruct, fileName,
+//         gcfg.ErrorHandler(gcfg.StopOnTargetNotFound))
+func StopOnTargetNotFound(e error) ErrorAction {
+	if _, ok := e.(TargetNotFoundError); ok {
+		return ErrorActionStop
+	}
+	return ErrorActionNone
+}
+
+// defaultErrorHandler is the fallback handler that the Read functions use if there is no
+// custom handler, or if the custom handler(s) all returned ErrorActionNone.
+func defaultErrorHandler(e error) ErrorAction {
+	switch e := e.(type) {
+	case TargetNotFoundError:
+		// Default for this type of error is to skip it.
+		// A LaunchDarkly addition to the standard gcfg behavior is that these errors are also logged to
+		// the console.
+		fmt.Printf("gcfg: %s\n", e)
+		return ErrorActionSuppress
+	case ValueError:
+		// Default for this type of error is to stop; the error will be returned to the caller.
+		return ErrorActionStop
+	case InvalidContainerError:
+		// Default behavior for this type of error is to panic.
+		panic(e)
+	default:
+		// Error handlers will normally receive one of the above types of errors; stop for any other type.
+		return ErrorActionStop
+	}
+}

--- a/read_options.go
+++ b/read_options.go
@@ -1,0 +1,55 @@
+package gcfg
+
+type readOptions struct {
+	errorHandlers        []func(error) ErrorAction
+	stopOnTargetNotFound bool
+}
+
+// ReadOption is a common interface for optional parameters that can be passed to
+// the Read functions.
+type ReadOption interface {
+	apply(*readOptions)
+}
+
+// ErrorHandler is an option for the Read functions which causes the specified function(s)
+// to be called whenever the configuration contains a name or value that is not valid for
+// the target data structure.
+//
+// There are several types of errors: see TargetNotFoundError, ValueError, and
+// InvalidContainerError. For any of these, gcfg will call the specified handler function(s)
+// in order. If a handler returns ErrorActionStop, gcfg will stop and return the error to
+// the caller. If a handler returns ErrorActionSuppress, gcfg will ignore the error.
+// Otherwise it will proceed to the next handler, if any, and if there are no more it will
+// fall back to the default error-handling behavior.
+//
+// The default error-handling behavior is that TargetNotFoundError is printed to the console
+// and then ignored; ValueError causes gcfg to stop and return the error, and
+// InvalidContainerError causes a panic.
+//
+// Two kinds of errors cannot be handled with ErrorHandler:
+//
+// 1. Errors that are due to an incorrectly formatted file, so that parsing cannot continue,
+// always cause the Read functions to immediately return the error (as a ParseError).
+//
+// 2. Passing a target interface{} value that is not a struct pointer to the Read functions
+// always causes a panic.
+//
+//     func logAndSkipValueErrors(e error) gcfg.ErrorAction {
+//         if _, ok := e.(gcfg.ValueError); ok {
+//             fmt.Printf("warning: %v\n", e)
+//             return gcfg.ErrorActionSuppress
+//         }
+//         return gcfg.ErrorActionNone
+//     }
+//
+//     err := gcfg.ReadFileInto(&configStruct, fileName,
+//         gcfg.ErrorHandler(logAndSkipValueErrors))
+func ErrorHandler(handler ...func(error) ErrorAction) ReadOption {
+	return readOptionErrorHandlers(handler)
+}
+
+type readOptionErrorHandlers []func(error) ErrorAction
+
+func (o readOptionErrorHandlers) apply(ro *readOptions) {
+	ro.errorHandlers = o
+}


### PR DESCRIPTION
The original `gcfg` implementation deliberately defined its error-handling behavior to be similar to how `json.Unmarshal` works:

1. If the document is malformed (syntax errors)— processing stops and the parser returns an error.
2. If there's a name-value pair in the file where the name _does_ correspond to a target field, but the value is not valid for the field type— processing stops and the parser returns an error.
3. If there's a name-value pair or section in the file that does _not_ correspond to a target field— gcfg just skips it.
4. If something in the file implies that field X ought to be a struct or a map, but it's not, `gcfg` panics.

Parts 1-3 are reasonable, but it's not hard to imagine use cases where they might not be quite what's wanted. For 2, you might not want to stop on the first error but instead accumulate a list of all the things that are wrong with the file. And for 3, you might want to flag unknown names as errors. That last part is especially important because, whereas `json.Unmarshal` is most often used to parse JSON documents that were programmatically generated, `gcfg` is most often used to parse configuration files that were typed in by humans. It's extremely easy to misspell `ImportantPropertyName` as `ImportantPorpertyName` and then not even notice that the program is simply ignoring that part of your configuration.

(Part 4 is highly questionable and something applications definitely might want to override. It's reasonable for a panic to happen in the case of a _programmer_ error, like passing the wrong type in code, but in this case a panic could be caused by a _data_ error, i.e. just adding a bad line to the config file.)

Rather than making assumptions about what rules would be best for every application, this PR provides a way to customize them with a callback. Problems of types 2/3/4 are passed to the callback, which can log them or do whatever else it wants, and then must return a value to tell `gcfg` whether to a) stop and return the error, b) continue, or c) defer to any other error handlers that may have been specified, or to the default behavior if none.

This is implemented via the variadic options pattern, so instead of `ReadInto(&dest, filename)` you can do `ReadInto(&dest, filename, ErrorHandler(...))`. That means it is backward-compatible in terms of normal usage, but it is not backward-compatible if you want to cast `ReadInto` to a specific function signature like `func(interface{}, string) error`. If that's a concern, it would be easy enough to add `ReadIntoWithOptions` etc.

There is one other change we've already made to the default behavior on this fork: in the LaunchDarkly version, "no such field" errors are printed to the console before being skipped. If we submit this new feature to the upstream repo and it's accepted, I think we can drop that earlier customization and just use the upstream repo— it's easy enough to add that printing behavior on an as-needed basis using this feature.